### PR TITLE
Add tailwindcss as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.1.0",
     "luxon": "^1.26.0",
     "markdown-it": "^12.0.4",
-    "markdown-it-anchor": "^7.1.0"
-  },
-  "dependencies": {
-    "@tailwindcss/typography": "^0.4.1"
+    "markdown-it-anchor": "^7.1.0",
+    "tailwindcss": "^2.2.19"
   }
 }


### PR DESCRIPTION
@222ridepegasus obviously not tested this with deployments, I'll ping you about that. Basically I realised that the npm package for tailwind wasn't included in the `package.json`. Unfortunately I think this was because of the tailwind-test folder that was accidentally included. 

This should fix:

- deployments 🥳
- autocomplete with the tailwind plugin 🙌

For deployments you should only need `npm run build` (you can get rid of the `npm run ci` bit)