### PR TITLE
Make build script run in series

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.2",
   "description": "A starter repository for a blog web site using the Eleventy static site generator.",
   "scripts": {
-    "build": "eleventy & npm run tailwind:build",
+    "build": "eleventy && npm run tailwind:build",
     "watch": "eleventy --watch & npm run tailwind:watch",
     "serve": "eleventy --serve",
     "start": "eleventy --serve & npm run tailwind:watch",


### PR DESCRIPTION
@222ridepegasus spotted a small issue that you can run into, you may have already. 

Changing `&` to `&&` makes sure that the Eleventy build finishes before the Tailwind build. You need to be sure that all the html files have been generated first, so that Tailwind can scan them for classes to add to the final CSS file. Otherwise it's likely that TW can miss new classes that you've added at build time. Hope that makes sense! 🥴